### PR TITLE
Added (some) missing UI translations & translations.

### DIFF
--- a/RelhaxModpack/RelhaxModpack/MainWindow.xaml
+++ b/RelhaxModpack/RelhaxModpack/MainWindow.xaml
@@ -146,7 +146,7 @@
                         </CheckBox>
                     </StackPanel>
                     <StackPanel Grid.Column="1">
-                        <TextBlock Text="Select theme:" />
+                        <TextBlock x:Name="ThemeSelectText" Tag="ThemeSelectText" Text="Select theme:" />
                         <StackPanel Orientation="Vertical" Margin="15,0,0,0">
                             <RadioButton x:Name="ThemeDefault" Tag="ThemeDefault" Checked="Theme_Checked">
                                 <TextBlock x:Name="ThemeDefaultText" Text="Default" TextWrapping="Wrap"/>

--- a/RelhaxModpack/RelhaxModpack/MainWindow.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/MainWindow.xaml.cs
@@ -990,6 +990,7 @@ namespace RelhaxModpack
                         CheckFileExists = true,
                         CheckPathExists = true,
                         Filter = "WorldOfTanks.exe|WorldOfTanks.exe",
+                        Title = Translations.GetTranslatedString("selectWOTExecutable"),
                         Multiselect = false,
                         ValidateNames = true
                     };
@@ -1953,6 +1954,7 @@ namespace RelhaxModpack
                     CheckFileExists = true,
                     CheckPathExists = true,
                     Filter = "WorldOfTanks.exe|WorldOfTanks.exe",
+                    Title = Translations.GetTranslatedString("selectWOTExecutable"),
                     Multiselect = false,
                     RestoreDirectory = true,
                     ValidateNames = true

--- a/RelhaxModpack/RelhaxModpack/Utils/Translations.cs
+++ b/RelhaxModpack/RelhaxModpack/Utils/Translations.cs
@@ -679,7 +679,7 @@ namespace RelhaxModpack
             Spanish.Add("InstallModpackButton", "Comenzar selección de Mods");
             Russian.Add("InstallModpackButton", "Начать выбор модов");
 
-            //Component: selectWOTExecutable
+            //Component: manualWoTFind
             // File picker window asking the user to select WorldOfTanks.exe manually.
             English.Add("selectWOTExecutable", "Select your WOT executable (WorldOfTanks.exe)");
             German.Add("selectWOTExecutable", TranslationNeeded);

--- a/RelhaxModpack/RelhaxModpack/Utils/Translations.cs
+++ b/RelhaxModpack/RelhaxModpack/Utils/Translations.cs
@@ -1323,7 +1323,7 @@ namespace RelhaxModpack
             //
             English.Add("SaveDisabledModsInSelectionDescription", "When a mod is re-enabled, it will be selected from your selection file");
             German.Add("SaveDisabledModsInSelectionDescription", "Wenn ein Mod wieder aktiviert wird, wird er aus deiner Auswahldatei ausgewählt");
-            Polish.Add("SaveDisabledModsInSelectionDescription", "Automatycznie zaznacza nieaktywne wybrane mody przy ich ponownym odblokowaniu.");
+            Polish.Add("SaveDisabledModsInSelectionDescription", "Zaznacza poprzednio wybrane, ale zablokowane przez nas mody, po ich ponownym odblokowaniu.");
             French.Add("SaveDisabledModsInSelectionDescription", "Quand un mod est réactivé, il sera sélectionné depuis votre sélection de fichiers");
             Spanish.Add("SaveDisabledModsInSelectionDescription", "Cuando un mod sea rehabilitado, será seleccionado desde su archivo de selección");
             Russian.Add("SaveDisabledModsInSelectionDescription", "Когда мод будет включён в БД, он снова будет выбран из вашей предустановки");
@@ -1341,7 +1341,7 @@ namespace RelhaxModpack
             //
             English.Add("AdvancedInstallationProgressDescription", "Shows an advanced installation window during extraction, useful when you have multicore extraction enabled");
             German.Add("AdvancedInstallationProgressDescription", "Zeigt während der Extraktion ein erweitertes Installationsfenster an, das nützlich ist, wenn die Multicore-Extraktion aktiviert ist");
-            Polish.Add("AdvancedInstallationProgressDescription", "Wyświetla rozbudowane okno procesu instalacji. Przydatne przy włączonym wyodrębnianiu wielordzeniowym.");
+            Polish.Add("AdvancedInstallationProgressDescription", "Wyświetla szczegółowe okno procesu instalacji. Przydatne przy włączonym wyodrębnianiu wielordzeniowym.");
             French.Add("AdvancedInstallationProgressDescription", "Montrer une fenêtre d'installation avancée pendant l'extraction, utile quand vous avez l'extraction multicoeurs activée");
             Spanish.Add("AdvancedInstallationProgressDescription", "Muestra una ventana de instalación avanzada durante la extracción, útil cuando la extración multinúcleo está habilitada");
             Russian.Add("AdvancedInstallationProgressDescription", "Показывает более подробное окно прогресса установки. Полезно при включённой многопоточной установке");
@@ -1473,7 +1473,7 @@ namespace RelhaxModpack
             //
             English.Add("UninstallQuickText", "Quick");
             German.Add("UninstallQuickText", "Schnell");
-            Polish.Add("UninstallQuickText", "Szybki");
+            Polish.Add("UninstallQuickText", "Szybka");
             French.Add("UninstallQuickText", "Rapide");
             Spanish.Add("UninstallQuickText", "Rápida");
             Russian.Add("UninstallQuickText", "Быстрый");
@@ -1519,8 +1519,8 @@ namespace RelhaxModpack
                 " Hover over a setting to have it explained.");
             German.Add("HelperText", "Willkommen im Relhax Modpack! Ich habe versucht, das Modpack so einfach wie möglich zu gestalten, aber Fragen können dennoch entstehen." +
                 " Rechtsklick auf eine Einstellung erklärt diese dann.");
-            Polish.Add("HelperText", "Witaj w Modpacku Relhax!\nMoim celem było stworzenie paczki modów tak prostej, jak to tylko możliwe,\n ale jeśli nadal czujesz się nieco zagubiony," +
-                " po prostu najedź kursorem na dowolną opcję i przeczytaj jej opis.");
+            Polish.Add("HelperText", "Witaj w Modpacku Relhax!\n\nMoim celem było stworzenie paczki modów tak prostej, jak to tylko możliwe,\n" +
+                "ale jeśli nadal czujesz się nieco zagubiony, po prostu najedź kursorem na dowolną opcję i przeczytaj jej opis.");
             French.Add("HelperText", "Bienvenue au Modpack Relhax! J'ai aissayé de faire le modpack le plus simple possible, mais des questions peuvent survenir." +
                 " Survolez un paramètre pour voire une explication.");
             Spanish.Add("HelperText", "¡Bienvenido a RelHax Modpack! He intentado hacer el Modpack tan sencillo como ha sido posible, pero aún así pueden surgir dudas." +
@@ -1541,7 +1541,7 @@ namespace RelhaxModpack
             //
             English.Add("NotifyIfSameDatabaseText", "Inform if no new database available (stable database only)");
             German.Add("NotifyIfSameDatabaseText", TranslationNeeded);//"Hinweis wenn es keine Aktuallisierungen gibt"
-            Polish.Add("NotifyIfSameDatabaseText", TranslationNeeded);//"Powiadom o braku nowej bazy danych" // Shortened. Kept splitting into two lines. @Nullmaruzero
+            Polish.Add("NotifyIfSameDatabaseText", "Powiadom o braku nowej bazy danych*");//"Powiadom o braku nowej bazy danych"
             French.Add("NotifyIfSameDatabaseText", TranslationNeeded);//"Informer si aucune nouvelle base de données est disponible"
             Spanish.Add("NotifyIfSameDatabaseText", TranslationNeeded);//"Informar si no hay nueva base de datos"
             Russian.Add("NotifyIfSameDatabaseText", TranslationNeeded);//"Уведомлять при отстутсвии новых баз данных"
@@ -1562,7 +1562,8 @@ namespace RelhaxModpack
             English.Add("NotifyIfSameDatabaseCBDescription", "Notify you if your last installed database version is the same. If so, it means that there is no update to any mods." +
                 " This only works with the stable database.");
             German.Add("NotifyIfSameDatabaseCBDescription", TranslationNeeded);
-            Polish.Add("NotifyIfSameDatabaseCBDescription", TranslationNeeded);
+            Polish.Add("NotifyIfSameDatabaseCBDescription", "Wyświetla powiadomienie kiedy używana jest najnowsza wersja bazy danych.\nOznacza to brak dostępnych aktualizacji modów.\n" +
+                "Opcja dostępna tylko dla stabilnej wersji bazy danych (nie BETA).");
             French.Add("NotifyIfSameDatabaseCBDescription", TranslationNeeded);
             Spanish.Add("NotifyIfSameDatabaseCBDescription", TranslationNeeded);
             Russian.Add("NotifyIfSameDatabaseCBDescription", TranslationNeeded);
@@ -1571,7 +1572,7 @@ namespace RelhaxModpack
             //
             English.Add("ShowInstallCompleteWindowText", "Show advanced install complete window");
             German.Add("ShowInstallCompleteWindowText", "Zeige erweitertes Fenster bei abgeschlossener Installation");
-            Polish.Add("ShowInstallCompleteWindowText", "Rozbudowane podsumowanie instalacji"); // Shortened. Kept splitting into two lines. @Nullmaruzero
+            Polish.Add("ShowInstallCompleteWindowText", "Szczegółowe podsumowanie instalacji");
             French.Add("ShowInstallCompleteWindowText", "Montrer la fenêtre d'installation complète terminée" );
             Spanish.Add("ShowInstallCompleteWindowText", "Ver ventana de instalación completada avanzada");
             Russian.Add("ShowInstallCompleteWindowText", "Показывать расширенное окно окончания установки");

--- a/RelhaxModpack/RelhaxModpack/Utils/Translations.cs
+++ b/RelhaxModpack/RelhaxModpack/Utils/Translations.cs
@@ -64,7 +64,7 @@ namespace RelhaxModpack
             "AutoInstallOneClickInstallSelectionFilePath",
             "AutoSyncFrequencyTexbox",
             "DeveloperSettingsHeaderDescription",
-            "AutoSyncCheckFrequencyTextBox",
+            //"AutoSyncCheckFrequencyTextBox",
             "AutoSyncCheckFrequencyTextBoxDescription",
             "DiagnosticsStatusTextBox",
             "seachCB",
@@ -679,6 +679,15 @@ namespace RelhaxModpack
             Spanish.Add("InstallModpackButton", "Comenzar selección de Mods");
             Russian.Add("InstallModpackButton", "Начать выбор модов");
 
+            //Component: selectWOTExecutable
+            // File picker window asking the user to select WorldOfTanks.exe manually.
+            English.Add("selectWOTExecutable", "Select your WOT executable (WorldOfTanks.exe)");
+            German.Add("selectWOTExecutable", TranslationNeeded);
+            Polish.Add("selectWOTExecutable", "Wybierz plik wykonywalny WOT (WorldOfTanks.exe)");
+            French.Add("selectWOTExecutable", TranslationNeeded);
+            Spanish.Add("selectWOTExecutable", TranslationNeeded);
+            Russian.Add("selectWOTExecutable", TranslationNeeded);
+
             //Component: InstallModpackButtonDescription
             //
             English.Add("InstallModpackButtonDescription", "Select the mods you want to install to your WoT client");
@@ -1224,6 +1233,16 @@ namespace RelhaxModpack
             Spanish.Add("LoadAutoSyncSelectionFileText", "Cargar archivo de selección");
             Russian.Add("LoadAutoSyncSelectionFileText", "Загрузить файл предустановки");
 
+            //Component: AutoSyncCheckFrequencyTextBox
+            // A label followed by a small text field asking for update check interval (time unit selected via a drop-list at the end of the line).
+            // Frequency: every [ ... ] {Minutes / Hours / Days}
+            English.Add("AutoSyncCheckFrequencyTextBox", "Frequency: every");
+            German.Add("AutoSyncCheckFrequencyTextBox", TranslationNeeded);
+            Polish.Add("AutoSyncCheckFrequencyTextBox", "Częstotliwość: co");
+            French.Add("AutoSyncCheckFrequencyTextBox", TranslationNeeded);
+            Spanish.Add("AutoSyncCheckFrequencyTextBox", TranslationNeeded);
+            Russian.Add("AutoSyncCheckFrequencyTextBox", TranslationNeeded);
+
             //Component: DeveloperSettingsHeader
             //
             English.Add("DeveloperSettingsHeader", "Developer Settings [!]");
@@ -1345,6 +1364,15 @@ namespace RelhaxModpack
             French.Add("AdvancedInstallationProgressDescription", "Montrer une fenêtre d'installation avancée pendant l'extraction, utile quand vous avez l'extraction multicoeurs activée");
             Spanish.Add("AdvancedInstallationProgressDescription", "Muestra una ventana de instalación avanzada durante la extracción, útil cuando la extración multinúcleo está habilitada");
             Russian.Add("AdvancedInstallationProgressDescription", "Показывает более подробное окно прогресса установки. Полезно при включённой многопоточной установке");
+
+            //Component: ThemeSelectText
+            // A label with 3 radio buttons underneach for selecting app's color theme.
+            English.Add("ThemeSelectText", "Select theme:");
+            German.Add("ThemeSelectText", TranslationNeeded);
+            Polish.Add("ThemeSelectText", "Wybierz motyw:");
+            French.Add("ThemeSelectText", TranslationNeeded);
+            Spanish.Add("ThemeSelectText", TranslationNeeded);
+            Russian.Add("ThemeSelectText", TranslationNeeded);
 
             //Component: ThemeDefaultText
             //
@@ -3517,7 +3545,7 @@ namespace RelhaxModpack
             //
             English.Add("DownloadWGPatchFilesText", "Download WG Patch files for any WG client via HTTP");
             German.Add("DownloadWGPatchFilesText", TranslationNeeded);
-            Polish.Add("DownloadWGPatchFilesText", "Pobierz pliki paczy WG dla dowolnego klienta (HTTP)");
+            Polish.Add("DownloadWGPatchFilesText", "Pobieranie aktualizacji dla gier WG (HTTP)");
             French.Add("DownloadWGPatchFilesText", TranslationNeeded);
             Spanish.Add("DownloadWGPatchFilesText", TranslationNeeded);
             Russian.Add("DownloadWGPatchFilesText", TranslationNeeded);
@@ -4735,7 +4763,7 @@ namespace RelhaxModpack
             //
             English.Add("GcDownloadStep1TabDescription", "Select the Wargaming client to collect data for (WoT, WoWs, WoWp)");
             German.Add("GcDownloadStep1TabDescription", TranslationNeeded);
-            Polish.Add("GcDownloadStep1TabDescription", "Wybierz grę WG, dla której chcesz zebrać dane (WoT, WoWs, WoWp)");
+            Polish.Add("GcDownloadStep1TabDescription", "Wybierz grę WG, dla której chcesz pobrać aktualizacje (WoT, WoWs, WoWp)");
             French.Add("GcDownloadStep1TabDescription", TranslationNeeded);
             Spanish.Add("GcDownloadStep1TabDescription", TranslationNeeded);
             Russian.Add("GcDownloadStep1TabDescription", TranslationNeeded);
@@ -4744,7 +4772,7 @@ namespace RelhaxModpack
             //
             English.Add("GcDownloadStep1SelectClientButton", "Select client");
             German.Add("GcDownloadStep1SelectClientButton", TranslationNeeded);
-            Polish.Add("GcDownloadStep1SelectClientButton", "Wybierz klienta");
+            Polish.Add("GcDownloadStep1SelectClientButton", "Wybierz klienta gry");
             French.Add("GcDownloadStep1SelectClientButton", TranslationNeeded);
             Spanish.Add("GcDownloadStep1SelectClientButton", TranslationNeeded);
             Russian.Add("GcDownloadStep1SelectClientButton", TranslationNeeded);
@@ -4771,7 +4799,7 @@ namespace RelhaxModpack
             //
             English.Add("GcDownloadSelectWgClient", "Select WG Client");
             German.Add("GcDownloadSelectWgClient", TranslationNeeded);
-            Polish.Add("GcDownloadSelectWgClient", "Widoczność (alpha)");
+            Polish.Add("GcDownloadSelectWgClient", "Wybierz klienta docelowej gry WG, dla której chcesz pobrać aktualizacje");
             French.Add("GcDownloadSelectWgClient", TranslationNeeded);
             Spanish.Add("GcDownloadSelectWgClient", TranslationNeeded);
             Russian.Add("GcDownloadSelectWgClient", TranslationNeeded);

--- a/RelhaxModpack/RelhaxModpack/Windows/Diagnostics.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/Diagnostics.xaml.cs
@@ -50,13 +50,14 @@ namespace RelhaxModpack.Windows
         private void ChangeInstall_Click(object sender, RoutedEventArgs e)
         {
             Logging.Info("Diagnostics: Selecting WoT install");
-            //show a standard WoT selection window from manual fine WoT.exe
+            //show a standard WoT selection window from manual find WoT.exe
             OpenFileDialog manualWoTFind = new OpenFileDialog()
             {
                 AddExtension = true,
                 CheckFileExists = true,
                 CheckPathExists = true,
                 Filter = "WorldOfTanks.exe|WorldOfTanks.exe",
+                Title = Translations.GetTranslatedString("selectWOTExecutable"),
                 Multiselect = false,
                 ValidateNames = true
             };

--- a/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
@@ -1652,6 +1652,7 @@ namespace RelhaxModpack.Windows
                     CheckPathExists = true,
                     AddExtension = true,
                     Filter = "XML files|*.xml",
+                    Title = Translations.GetTranslatedString("MainWindowSelectSelectionFileToLoad"),
                     Multiselect = false,
                     ValidateNames = true
                 };


### PR DESCRIPTION
As per your advice, I tried my best to get rid of the unhandled translations. As C# and .NET are not my things, the volume of results is somewhat disappointing 😞 

I didn't touch the DB editor strings (I would need to see it in action first), patch tester etc.
I also gave up on Color Picker brush types because that's some serious voodoo right there beyond my pay grade, the whole algorithm works based on those strings so making it "translatable" kept breaking the whole thing.
Plus I have skipped the auto-update frequency unit selector button strings.