### PR TITLE
changed window preview behavior

### DIFF
--- a/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
@@ -1574,9 +1574,17 @@ namespace RelhaxModpack.Windows
             if (LoadingUI)
                 return;
 
+            //if it's not mouseEventArgs, then abort because we can't determine if it's a right click
             if (e is MouseEventArgs m)
+            {
                 if (m.RightButton != MouseButtonState.Pressed)
                     return;
+            }
+            else
+            {
+                Logging.Error(LogOptions.ClassName, "Unknown event type for mouse down event: {0}", e.GetType().ToString());
+                return;
+            }
 
             SelectablePackage spc = null;
             bool comboboxItemsInside = false;

--- a/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
@@ -135,7 +135,7 @@ namespace RelhaxModpack.Windows
         private bool continueInstallation  = false;
         private ProgressIndicator loadingProgress = null;
         private Category UserCategory = null;
-        private Preview p = null;
+        private Preview previewWindow = null;
         private const int FLASH_TICK_INTERVAL = 250;
         private const int NUM_FLASH_TICKS = 5;
         private int numTicks = 0;
@@ -188,10 +188,10 @@ namespace RelhaxModpack.Windows
         private void RelhaxWindow_Closed(object sender, EventArgs e)
         {
             //close and dispose preview
-            if (p != null)
+            if (previewWindow != null)
             {
-                p.Close();
-                p = null;
+                previewWindow.Close();
+                previewWindow = null;
             }
 
             //save width and height settings
@@ -1651,19 +1651,38 @@ namespace RelhaxModpack.Windows
                 return;
             }
 
-            if (p != null)
+            //if preview window for the first time, create and show
+            //if its not a virgin preview window, use the currently existing one but refresh the contents
+            if (previewWindow != null)
             {
-                p.Close();
-                p = null;
+                previewWindow.ComboBoxItemsInsideMode = comboboxItemsInside;
+                previewWindow.Medias = spc.Medias;
+                previewWindow.InvokedPackage = spc;
+                previewWindow.Refresh();
+
+            }
+            else if (previewWindow == null)
+            {
+                previewWindow = new Preview()
+                {
+                    ComboBoxItemsInsideMode = comboboxItemsInside,
+                    Medias = spc.Medias,
+                    InvokedPackage = spc
+                };
+                previewWindow.Show();
             }
 
-            p = new Preview()
+            //handle if the preview window was closed after one was viewed, and start up a new one
+            if (Application.Current.Windows.OfType<Preview>().SingleOrDefault() == null)
             {
-                ComboBoxItemsInsideMode = comboboxItemsInside,
-                Medias = spc.Medias,
-                InvokedPackage = spc
-            };
-            p.Show();
+                previewWindow = new Preview()
+                {
+                    ComboBoxItemsInsideMode = comboboxItemsInside,
+                    Medias = spc.Medias,
+                    InvokedPackage = spc
+                };
+                previewWindow.Show();
+            }
         }
 
         //Handler for allowing right click of disabled mods (WPF)
@@ -3117,8 +3136,8 @@ namespace RelhaxModpack.Windows
                     if (loadingProgress != null)
                         loadingProgress = null;
 
-                    if (p != null)
-                        p = null;
+                    if (previewWindow != null)
+                        previewWindow = null;
 
                     if (OriginalBrush != null)
                         OriginalBrush = null;

--- a/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/ModSelectionList.xaml.cs
@@ -1659,29 +1659,18 @@ namespace RelhaxModpack.Windows
                 return;
             }
 
-            //if preview window for the first time, create and show
-            //if its not a virgin preview window, use the currently existing one but refresh the contents
-            if (previewWindow != null)
+            //check if the window reference exists and if it's loaded (not a closed window, can't re-open a closed window)
+            //https://stackoverflow.com/a/49477128/3128017
+            //https://stackoverflow.com/a/26124156/3128017
+            if (previewWindow != null && previewWindow.IsLoaded)
             {
+                //if its not a virgin preview window, use the currently existing one but refresh the contents
                 previewWindow.ComboBoxItemsInsideMode = comboboxItemsInside;
                 previewWindow.Medias = spc.Medias;
                 previewWindow.InvokedPackage = spc;
-                previewWindow.Refresh();
-
+                previewWindow.Refresh(false);
             }
-            else if (previewWindow == null)
-            {
-                previewWindow = new Preview()
-                {
-                    ComboBoxItemsInsideMode = comboboxItemsInside,
-                    Medias = spc.Medias,
-                    InvokedPackage = spc
-                };
-                previewWindow.Show();
-            }
-
-            //handle if the preview window was closed after one was viewed, and start up a new one
-            if (Application.Current.Windows.OfType<Preview>().SingleOrDefault() == null)
+            else
             {
                 previewWindow = new Preview()
                 {

--- a/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
@@ -198,7 +198,10 @@ namespace RelhaxModpack.Windows
             }
 
             //start the focus timer to bring focus to this window
-            OMCViewLegacyFocusTimer.Start();
+            if (OMCViewLegacyFocusTimer == null)
+                OMCViewLegacyFocusTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(10), DispatcherPriority.Normal, Timer_Tick, this.Dispatcher) { IsEnabled = true };
+            else
+                OMCViewLegacyFocusTimer.Start();
         }
 
         private async void DisplayMedia(Media media)

--- a/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
@@ -193,6 +193,9 @@ namespace RelhaxModpack.Windows
                 PreviewUpdatesBox.Text = InvokedPackage.UpdateCommentFormatted;
                 CurrentDisplaySP = InvokedPackage;
             }
+
+            //start the focus timer to bring focus to this window
+            OMCViewLegacyFocusTimer.Start();
         }
 
         private async void DisplayMedia(Media media)

--- a/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
@@ -170,6 +170,9 @@ namespace RelhaxModpack.Windows
             }
         }
 
+        /// <summary>
+        /// Refresh the window to display new preview elements
+        /// </summary>
         public void Refresh()
         {
             if (Medias.Count > 0)

--- a/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
+++ b/RelhaxModpack/RelhaxModpack/Windows/Preview.xaml.cs
@@ -170,6 +170,31 @@ namespace RelhaxModpack.Windows
             }
         }
 
+        public void Refresh()
+        {
+            if (Medias.Count > 0)
+            {
+                DisplayMedia(Medias[0]);
+            }
+            else if (Medias.Count == 0)
+            {
+                CurrentDispalyMedia = null;
+            }
+            else
+            {
+                if (EditorMode)
+                    Title = "EDITOR_TEST_MODE";
+                else if (ComboBoxItemsInsideMode)
+                    Title = string.Format("{0}: ({1})", Translations.GetTranslatedString("dropDownItemsInside"), Translations.GetTranslatedString("none"));
+                else
+                    Title = InvokedPackage.NameFormatted;
+
+                PreviewDescriptionBox.Text = InvokedPackage.DescriptionFormatted;
+                PreviewUpdatesBox.Text = InvokedPackage.UpdateCommentFormatted;
+                CurrentDisplaySP = InvokedPackage;
+            }
+        }
+
         private async void DisplayMedia(Media media)
         {
             //the devURL, description and update notes only need to be

--- a/RelhaxModpack/RelhaxModpack/bin/Debug/RelhaxModpack.xml
+++ b/RelhaxModpack/RelhaxModpack/bin/Debug/RelhaxModpack.xml
@@ -7297,6 +7297,11 @@
             Create an instance of the Preview window
             </summary>
         </member>
+        <member name="M:RelhaxModpack.Windows.Preview.Refresh(System.Boolean)">
+            <summary>
+            Refresh the window to display new preview elements
+            </summary>
+        </member>
         <member name="M:RelhaxModpack.Windows.Preview.InitializeComponent">
             <summary>
             InitializeComponent


### PR DESCRIPTION
Created a refresh method in the preview window class to reinit a bunch of stuff and not have to close and show a new window. Then added logic into the modselectionlist to not close the preview window on a mouse click and instead use the refresh method, re-using the same window.